### PR TITLE
Fix weblogic's FORWARD only request path on non-forward requests

### DIFF
--- a/sitemesh/src/main/java/org/sitemesh/webapp/WebAppContext.java
+++ b/sitemesh/src/main/java/org/sitemesh/webapp/WebAppContext.java
@@ -95,7 +95,12 @@ public class WebAppContext extends BaseSiteMeshContext {
         if (request.getAttribute(FORWARD_SERVLET_PATH) != null) {
         	result = (String) request.getAttribute(FORWARD_SERVLET_PATH);
         } else {
-        	result = request.getServletPath();
+        	String requestUrl = request.getRequestURL().toString();
+        	if (request.getContextPath().length() == 0) {
+                result = requestUrl.substring(requestUrl.indexOf("/", 1 + requestUrl.indexOf("/", 1 + requestUrl.indexOf("/"))));
+        	} else {
+                result = requestUrl.substring(requestUrl.indexOf(request.getContextPath()) + request.getContextPath().length());
+        	}
         }
         
         String pathInfo = request.getPathInfo();


### PR DESCRIPTION
It seems like weblogic's decorator might reuse the same request object when retrieving a FORWARD jsp, making the `getServletPath` return the jsp url, instead of the request url. Even if the filter is not registered on the FORWARD dispatcher.

This fixes this by calculating the requestUrl.

This passes all tests, however, if someone was dependent on jsp path decoration, then this would break them.