### PR TITLE
Javadoc fix for MetaTagBasedDecoratorSelector

### DIFF
--- a/sitemesh/src/main/java/org/sitemesh/config/MetaTagBasedDecoratorSelector.java
+++ b/sitemesh/src/main/java/org/sitemesh/config/MetaTagBasedDecoratorSelector.java
@@ -13,7 +13,7 @@ import java.io.IOException;
  * <h3>Example</h3>
  * 
  * <pre>
- * <meta name="decorator" content="/my-decorator,/my-other-decorator">
+ * &lt;meta name="decorator" content="/my-decorator,/my-other-decorator"&gt;
  * </pre>
  * 
  * @author Joe Walnes


### PR DESCRIPTION
Hi,

Here is a trivial javadoc fix for MetaTagBasedDecoratorSelector.