### PR TITLE
allow decorator chaining in "SiteMeshAutoConfiguration"

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -51,8 +51,12 @@ sitemesh:
     mappings:
       - path: /admin/*
         decorator: admin.html
+      - path: /board/*
+        decorator: board.html,default.html   # comma-separated decorators are applied as a chain
   dispatchMode: detect            # include | forward | detect — how decorators are dispatched
 ```
+
+`sitemesh.decorator.default` and each mapping's `decorator` accept a comma-separated list of decorators, which are applied as a chain (the content is decorated by the first, the result by the next, and so on) — the same syntax the `<meta name="decorator">` tag supports.
 
 `sitemesh.includeErrorPages` (default `true`) is also shared: in both integrations it controls whether responses with an error status (>= 400) — e.g. Spring Boot's `error` view — are still decorated. `sitemesh.filter.order` (default `29`) applies to the filter integration only.
 

--- a/spring-boot-starter-sitemesh/build.gradle
+++ b/spring-boot-starter-sitemesh/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     implementation project(':spring-webmvc-sitemesh')
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor:4.1.0'
+
+    testImplementation 'junit:junit:4.13.2'
 }
 
 // Make the manually maintained META-INF/additional-spring-configuration-metadata.json

--- a/spring-boot-starter-sitemesh/src/main/java/org/sitemesh/autoconfigure/DecoratorComponentsFactory.java
+++ b/spring-boot-starter-sitemesh/src/main/java/org/sitemesh/autoconfigure/DecoratorComponentsFactory.java
@@ -67,6 +67,10 @@ class DecoratorComponentsFactory {
      * a {@link RequestAttributeDecoratorSelector} when an attribute is set,
      * a plain {@link MetaTagBasedDecoratorSelector} otherwise.
      *
+     * <p>The {@code default} and per-mapping {@code decorator} values accept a
+     * comma-separated list of decorators, applied as a chain — the same syntax
+     * the {@code <meta name="decorator">} tag supports.</p>
+     *
      * @param skipIncompleteMappings whether mapping entries missing a
      *                               {@code path} or {@code decorator} key are
      *                               silently skipped instead of applied as-is
@@ -78,16 +82,20 @@ class DecoratorComponentsFactory {
                 : new MetaTagBasedDecoratorSelector<C>();
         selector.setMetaTagName(decorator.getMetaTag()).setPrefix(decorator.getPrefix());
         if (decorator.getDefault() != null) {
-            selector.put("/*", decorator.getDefault());
+            selector.put("/*", decorator.getDefault().split(","));
         }
         if (decorator.getMappings() != null) {
             for (Map<String, String> mapping : decorator.getMappings()) {
                 String path = mapping.get("path");
-                String decoratorPath = mapping.get("decorator");
-                if (skipIncompleteMappings && (path == null || decoratorPath == null)) {
+                String decoratorPaths = mapping.get("decorator");
+                if (skipIncompleteMappings && (path == null || decoratorPaths == null)) {
                     continue;
                 }
-                selector.put(path, decoratorPath);
+                if (decoratorPaths == null) {
+                    selector.put(path, (String) null);
+                } else {
+                    selector.put(path, decoratorPaths.split(","));
+                }
             }
         }
         return selector;

--- a/spring-boot-starter-sitemesh/src/main/java/org/sitemesh/autoconfigure/SiteMeshProperties.java
+++ b/spring-boot-starter-sitemesh/src/main/java/org/sitemesh/autoconfigure/SiteMeshProperties.java
@@ -183,13 +183,16 @@ public class SiteMeshProperties {
 
         /**
          * Decorator applied to every path ("/*") unless a more specific
-         * mapping, meta tag or request attribute overrides it.
+         * mapping, meta tag or request attribute overrides it. A
+         * comma-separated list applies the decorators as a chain.
          */
         private String defaultDecorator;
 
         /**
          * Path-to-decorator mappings. Each entry is a map with a "path" key
-         * (e.g. "/admin/*") and a "decorator" key (e.g. "admin.html").
+         * (e.g. "/admin/*") and a "decorator" key (e.g. "admin.html"). A
+         * comma-separated "decorator" value (e.g. "panel.html,admin.html")
+         * applies the decorators as a chain.
          */
         private List<Map<String, String>> mappings;
 
@@ -264,7 +267,8 @@ public class SiteMeshProperties {
         /**
          * The decorator applied to every path ({@code "/*"}).
          *
-         * @return the default decorator, or null (the default) for none
+         * @return the default decorator (a comma-separated list chains
+         *         several), or null (the default) for none
          */
         public String getDefault() {
             return defaultDecorator;
@@ -273,7 +277,8 @@ public class SiteMeshProperties {
         /**
          * Sets the decorator applied to every path ({@code "/*"}).
          *
-         * @param defaultDecorator the default decorator name/path
+         * @param defaultDecorator the default decorator name/path; a
+         *                         comma-separated list chains several
          */
         public void setDefault(String defaultDecorator) {
             this.defaultDecorator = defaultDecorator;
@@ -291,7 +296,9 @@ public class SiteMeshProperties {
         /**
          * Sets the path-to-decorator mappings.
          *
-         * @param mappings the mappings, each with a "path" and a "decorator" key
+         * @param mappings the mappings, each with a "path" and a "decorator"
+         *                 key; a comma-separated "decorator" value chains
+         *                 several decorators
          */
         public void setMappings(List<Map<String, String>> mappings) {
             this.mappings = mappings;

--- a/spring-boot-starter-sitemesh/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-starter-sitemesh/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -4,7 +4,7 @@
       "name": "sitemesh.decorator.default",
       "type": "java.lang.String",
       "sourceType": "org.sitemesh.autoconfigure.SiteMeshProperties$Decorator",
-      "description": "Decorator applied to every path (\"/*\") unless a more specific mapping, meta tag or request attribute overrides it."
+      "description": "Decorator applied to every path (\"/*\") unless a more specific mapping, meta tag or request attribute overrides it. A comma-separated list applies the decorators as a chain."
     },
     {
       "name": "sitemesh.filter.order",

--- a/spring-boot-starter-sitemesh/src/test/java/org/sitemesh/autoconfigure/DecoratorComponentsFactoryTest.java
+++ b/spring-boot-starter-sitemesh/src/test/java/org/sitemesh/autoconfigure/DecoratorComponentsFactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ *    Copyright 2009-2026 SiteMesh authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.sitemesh.autoconfigure;
+
+import java.util.List;
+import java.util.Map;
+
+import junit.framework.TestCase;
+import org.sitemesh.config.MetaTagBasedDecoratorSelector;
+
+/**
+ * @see DecoratorComponentsFactory
+ */
+public class DecoratorComponentsFactoryTest extends TestCase {
+
+    private SiteMeshProperties.Decorator decorator;
+
+    @Override
+    protected void setUp() {
+        decorator = new SiteMeshProperties.Decorator();
+    }
+
+    private MetaTagBasedDecoratorSelector<?> buildSelector(boolean skipIncompleteMappings) {
+        return new DecoratorComponentsFactory(decorator).buildDecoratorSelector(skipIncompleteMappings);
+    }
+
+    public void testMapsPathToSingleDecorator() {
+        decorator.setMappings(List.of(Map.of("path", "/admin/*", "decorator", "admin.html")));
+
+        MetaTagBasedDecoratorSelector<?> selector = buildSelector(true);
+
+        assertDecorators(selector, "/admin/users", "admin.html");
+    }
+
+    public void testCommaSeparatedMappingDecoratorsAreChained() {
+        decorator.setMappings(List.of(Map.of("path", "/board/*", "decorator", "board.html,default.html")));
+
+        MetaTagBasedDecoratorSelector<?> selector = buildSelector(true);
+
+        assertDecorators(selector, "/board/topics", "board.html", "default.html");
+    }
+
+    public void testCommaSeparatedDefaultDecoratorsAreChained() {
+        decorator.setDefault("panel.html,default.html");
+
+        MetaTagBasedDecoratorSelector<?> selector = buildSelector(true);
+
+        assertDecorators(selector, "/anything", "panel.html", "default.html");
+    }
+
+    public void testIncompleteMappingIsSkippedWhenRequested() {
+        decorator.setMappings(List.of(Map.of("path", "/admin/*")));
+
+        MetaTagBasedDecoratorSelector<?> selector = buildSelector(true);
+
+        assertNull(selector.getPathMapper().get("/admin/users"));
+    }
+
+    private void assertDecorators(MetaTagBasedDecoratorSelector<?> selector, String path, String... expected) {
+        String[] actual = selector.getPathMapper().get(path);
+        assertNotNull("no decorators mapped for " + path, actual);
+        assertEquals(List.of(expected), List.of(actual));
+    }
+}


### PR DESCRIPTION
You can input decorators as a list.

application.properties
```properties
sitemesh.decorator.mappings.0.path=/*
sitemesh.decorator.mappings.0.decorator=board.html,default.html
```